### PR TITLE
Add Jenkinsfile for CI pipeline to build the project and run unit & integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,39 @@
+pipeline {
+    agent any
+
+    environment {
+        PATH = "/root/.dotnet:$PATH"
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Verify .NET Installation') {
+            steps {
+                sh 'dotnet --info'
+            }
+        }
+
+        stage('Restore Dependencies') {
+            steps {
+                sh 'dotnet restore'
+            }
+        }
+
+        stage('Build') {
+            steps {
+                sh 'dotnet build --no-restore'
+            }
+        }
+
+        stage('Run Tests') {
+            steps {
+                sh 'dotnet test --verbosity normal'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a Jenkinsfile to automate the CI process. By merging this branch, Jenkins will automatically trigger the build and test process whenever changes are pushed to the develop branch. 